### PR TITLE
Added whereIsNull and whereIsNotNull to RushSearch to allow querying for null fields

### DIFF
--- a/src/main/java/co/uk/rushorm/core/RushSearch.java
+++ b/src/main/java/co/uk/rushorm/core/RushSearch.java
@@ -274,6 +274,16 @@ public class RushSearch {
         return this;
     }
 
+    public RushSearchEx whereIsNull(String field) {
+        whereStatements.add(new RushWhere(field + " IS NULL"));
+        return this;
+    }
+
+    public RushSearchEx whereIsNotNull(String field) {
+        whereStatements.add(new RushWhere(field + " IS NOT NULL"));
+        return this;
+    }
+
     public RushSearch orderDesc(String field){
         orderStatements.add(new RushOrderBy(field, "DESC"));
         return this;


### PR DESCRIPTION
See https://github.com/Stuart-campbell/RushOrm/issues/72
