### PR TITLE
Call LoadCallback after filling all object's fields

### DIFF
--- a/src/main/java/co/uk/rushorm/core/implementation/ReflectionClassLoader.java
+++ b/src/main/java/co/uk/rushorm/core/implementation/ReflectionClassLoader.java
@@ -96,9 +96,6 @@ public class ReflectionClassLoader implements RushClassLoader {
         }
         T object = clazz.newInstance();
 
-        loadedClasses.get(clazz).put(rushMetaData.getId(), object);
-        callback.didLoadObject(object, rushMetaData);
-
         List<Field> fields = new ArrayList<>();
         ReflectionUtils.getAllFields(fields, clazz, rushConfig.orderColumnsAlphabetically());
 
@@ -117,6 +114,10 @@ public class ReflectionClassLoader implements RushClassLoader {
                 }
             }
         }
+
+        loadedClasses.get(clazz).put(rushMetaData.getId(), object);
+        callback.didLoadObject(object, rushMetaData);
+
         return object;
     }
 


### PR DESCRIPTION
If override hashCode() found object will be with null getId and empty Rush-children.
See https://github.com/Stuart-campbell/RushOrm/issues/78
