### PR TITLE
Fixed whereIN for an empty list

### DIFF
--- a/src/main/java/co/uk/rushorm/core/RushSearch.java
+++ b/src/main/java/co/uk/rushorm/core/RushSearch.java
@@ -312,7 +312,9 @@ public class RushSearch {
         for (String value : values) {
             inStatement += value + ",";
         }
-        inStatement = inStatement.substring(0, inStatement.length() - 1) + ")";
+        if(!values.isEmpty())
+            inStatement = inStatement.substring(0, inStatement.length() - 1);
+        inStatement += ")";
         whereStatements.add(new RushWhereStatement(column, " IN ", inStatement));
         return this;
     }

--- a/src/main/java/co/uk/rushorm/core/RushSearch.java
+++ b/src/main/java/co/uk/rushorm/core/RushSearch.java
@@ -312,8 +312,9 @@ public class RushSearch {
         for (String value : values) {
             inStatement += value + ",";
         }
-        if(!values.isEmpty())
+        if(!values.isEmpty()) {
             inStatement = inStatement.substring(0, inStatement.length() - 1);
+        }
         inStatement += ")";
         whereStatements.add(new RushWhereStatement(column, " IN ", inStatement));
         return this;


### PR DESCRIPTION
whereIN generated an invalid SQL statement if the list was empty, because the first parenthesis would be removed.